### PR TITLE
Add subtitle to index cards

### DIFF
--- a/docs/subtitle-feature.md
+++ b/docs/subtitle-feature.md
@@ -24,11 +24,19 @@ When creating or editing a post in Sanity Studio, you'll find a new "Subtitle" f
 
 ## Styling
 
+### Individual Blog Post Pages
 The subtitle is styled with:
 - Font size: 1.8rem (smaller than the main title's 2.5rem)
 - Color: Gray-dark (darker gray for better readability)
 - Font weight: 600 (semi-bold)
 - Spacing: Positioned close to the title with proper margin
+
+### Blog Listing Cards
+The subtitle on the blog index page cards is styled with:
+- Font size: 1.1rem (smaller and more compact for card views)
+- Color: Gray (medium gray)
+- Font weight: 600 (semi-bold)
+- Spacing: Positioned between title and date
 
 ## Example Use Cases
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -36,6 +36,7 @@ const posts = await sanityClient.fetch(`
   *[_type == "post"] | order(_createdAt desc) {
     _id,
     title,
+    subtitle,
     "slug": slug.current,
 	"heroImage": heroImage.asset->url + "?w=720&h=360&fit=crop&auto=format",
     _createdAt
@@ -100,6 +101,14 @@ const posts = await sanityClient.fetch(`
 				line-height: 1;
 				margin-bottom: 0.5rem;
 			}
+			.subtitle {
+				margin: 0;
+				color: rgb(var(--gray));
+				font-size: 1.1rem;
+				font-weight: 600;
+				line-height: 1.3;
+				margin-bottom: 0.5rem;
+			}
 			.date {
 				margin: 0;
 				color: rgb(var(--gray));
@@ -147,6 +156,7 @@ const posts = await sanityClient.fetch(`
                                         <img width={720} height={360} src={post.heroImage} alt={post.title} />
                                     )}
                                     <h4 class="title">{post.title}</h4>
+                                    {post.subtitle && <p class="subtitle">{post.subtitle}</p>}
                                     <p class="date">
                                         <FormattedDate date={new Date(post._createdAt)} />
                                     </p>


### PR DESCRIPTION
Add subtitle feature to index cards 

The subtitle on the blog index page cards is styled with:
- Font size: 1.1rem (smaller and more compact for card views)
- Color: Gray (medium gray)
- Font weight: 600 (semi-bold)
- Spacing: Positioned between title and date