### PR TITLE
Add handwritten notes component with three styles

### DIFF
--- a/src/components/PortableText.astro
+++ b/src/components/PortableText.astro
@@ -9,6 +9,7 @@ import PortableTextCodeBlock from './PortableTextCodeBlock.astro';
 import PortableTextChatConversation from './PortableTextChatConversation.astro';
 import PortableTextContainerColumns from './PortableTextContainerColumns.astro';
 import PortableTextNewspaperColumns from './PortableTextNewspaperColumns.astro';
+import PortableTextHandwrittenNote from './PortableTextHandwrittenNote.astro';
 
 const { value } = Astro.props;
 
@@ -22,6 +23,7 @@ const components = {
     chatConversation: PortableTextChatConversation,
     containerColumns: PortableTextContainerColumns,
     newspaperColumns: PortableTextNewspaperColumns,
+    handwrittenNote: PortableTextHandwrittenNote,
   },
 };
 ---

--- a/src/components/PortableTextHandwrittenNote.astro
+++ b/src/components/PortableTextHandwrittenNote.astro
@@ -1,0 +1,269 @@
+---
+import { PortableText } from 'astro-portabletext';
+
+const { node } = Astro.props;
+
+if (!node || !node.content) {
+  console.error("PortableTextHandwrittenNote missing content:", Astro.props);
+  return null;
+}
+
+const { content, style = 'postit', colorVariant = 'yellow' } = node;
+const noteId = `note-${Math.random().toString(36).substr(2, 9)}`;
+---
+
+<div 
+  class={`handwritten-note note-${style} note-color-${colorVariant}`}
+  data-note-id={noteId}
+>
+  <div class="note-content">
+    <PortableText value={content} />
+  </div>
+</div>
+
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&family=Permanent+Marker&display=swap');
+
+  .handwritten-note {
+    margin: 2rem auto;
+    padding: 1.5rem 2rem;
+    max-width: 600px;
+    font-family: 'Caveat', cursive;
+    font-size: 1.3rem;
+    line-height: 1.6;
+    color: #4a4a4a;
+    position: relative;
+    clear: both;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  /* Post-it Note Style */
+  .note-postit {
+    border-radius: 0;
+    transform: rotate(-0.5deg);
+    box-shadow: 
+      0 1px 2px rgba(0, 0, 0, 0.08),
+      0 4px 8px rgba(0, 0, 0, 0.06);
+    max-width: 300px;
+    font-family: 'Permanent Marker', cursive;
+    font-size: 2.6rem;
+    line-height: 1.4;
+    color: #2a2a2a;
+    font-weight: normal;
+    background: #fffacd !important;
+    padding: 2rem 2.5rem;
+  }
+
+  /* Post-it specific content styling */
+  .note-postit .note-content :global(p) {
+    margin: 0.6rem 0;
+  }
+
+  .note-postit .note-content :global(ul li) {
+    padding-left: 2rem;
+    margin: 0.4rem 0;
+  }
+
+  .note-postit .note-content :global(ul li::before) {
+    font-size: 2.6rem;
+  }
+
+  .note-postit .note-content :global(ol li) {
+    padding-left: 3rem;
+    margin: 0.4rem 0;
+  }
+
+  .note-postit .note-content :global(ol li::before) {
+    font-size: 2.6rem;
+  }
+
+  .note-postit::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 30px;
+    background: linear-gradient(to bottom, 
+      rgba(0, 0, 0, 0.05) 0%, 
+      rgba(0, 0, 0, 0) 100%);
+    border-radius: 0;
+  }
+
+  /* Field Notes Style */
+  .note-fieldnotes {
+    border-radius: 3px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    background-image: 
+      repeating-linear-gradient(
+        transparent,
+        transparent 31px,
+        rgba(0, 0, 0, 0.08) 31px,
+        rgba(0, 0, 0, 0.08) 32px
+      );
+    padding-top: 2rem;
+  }
+
+  .note-fieldnotes::after {
+    content: 'FIELD NOTES';
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    font-size: 0.7rem;
+    letter-spacing: 1px;
+    opacity: 0.3;
+    font-family: monospace;
+    font-weight: bold;
+  }
+
+  /* Notebook Page Style */
+  .note-notebook {
+    border-left: 3px solid #e74c3c;
+    border-radius: 0;
+    background-color: #f5f5f5;
+    background-image: 
+      repeating-linear-gradient(
+        transparent,
+        transparent 31px,
+        #d0d0d0 31px,
+        #d0d0d0 32px
+      );
+    background-position-y: 24px;
+    padding-left: 2.5rem;
+    padding-top: 1.5rem;
+    padding-bottom: 1.5rem;
+    position: relative;
+    line-height: 32px;
+  }
+
+  /* Notebook specific content styling - fixed spacing */
+  .note-notebook .note-content :global(p) {
+    margin: 0;
+    line-height: 32px;
+  }
+
+  .note-notebook .note-content :global(ul),
+  .note-notebook .note-content :global(ol) {
+    margin: 0;
+  }
+
+  .note-notebook .note-content :global(ul li),
+  .note-notebook .note-content :global(ol li) {
+    margin: 0;
+    line-height: 32px;
+  }
+
+  .note-notebook .note-content :global(strong),
+  .note-notebook .note-content :global(em) {
+    line-height: 32px;
+  }
+
+  .note-notebook::before {
+    content: '';
+    position: absolute;
+    left: 2rem;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: #e74c3c;
+    opacity: 0.3;
+  }
+
+  /* Color Variants - Only for Field Notes */
+  .note-fieldnotes.note-color-yellow {
+    background: #fffacd;
+  }
+
+  .note-fieldnotes.note-color-cream {
+    background: #fef9e7;
+  }
+
+  .note-fieldnotes.note-color-gray {
+    background: #f5f5f5;
+  }
+
+  .note-fieldnotes.note-color-blue {
+    background: #e3f2fd;
+  }
+
+  .note-fieldnotes.note-color-green {
+    background: #e8f5e9;
+  }
+
+  /* Content Styling */
+  .note-content :global(p) {
+    margin: 0.5rem 0;
+    color: #3a3a3a;
+  }
+
+  .note-content :global(strong) {
+    font-weight: 700;
+    color: #2a2a2a;
+  }
+
+  .note-content :global(em) {
+    font-style: italic;
+  }
+
+  /* List Styling - Dash bullets for handwritten feel */
+  .note-content :global(ul) {
+    list-style: none;
+    padding-left: 0;
+    margin: 0.5rem 0;
+  }
+
+  .note-content :global(ul li) {
+    position: relative;
+    padding-left: 1.5rem;
+    margin: 0.3rem 0;
+  }
+
+  .note-content :global(ul li::before) {
+    content: '–';
+    position: absolute;
+    left: 0;
+    font-weight: bold;
+    color: #5a5a5a;
+  }
+
+  /* Numbered Lists */
+  .note-content :global(ol) {
+    list-style: none;
+    counter-reset: note-counter;
+    padding-left: 0;
+    margin: 0.5rem 0;
+  }
+
+  .note-content :global(ol li) {
+    position: relative;
+    padding-left: 2rem;
+    margin: 0.3rem 0;
+    counter-increment: note-counter;
+  }
+
+  .note-content :global(ol li::before) {
+    content: counter(note-counter) '.';
+    position: absolute;
+    left: 0;
+    font-weight: bold;
+    color: #5a5a5a;
+  }
+
+  /* Nested lists */
+  .note-content :global(ul ul),
+  .note-content :global(ol ol),
+  .note-content :global(ul ol),
+  .note-content :global(ol ul) {
+    margin-left: 1rem;
+    margin-top: 0.2rem;
+  }
+
+  /* Responsive adjustments */
+  @media (max-width: 768px) {
+    .handwritten-note {
+      margin: 1.5rem 1rem;
+      padding: 1.25rem 1.5rem;
+      font-size: 1.2rem;
+    }
+  }
+</style>

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -12,7 +12,8 @@ import codeBlock from "./objects/codeBlock";
 import chatConversation from "./objects/chatConversation";
 import containerColumns from "./objects/containerColumns";
 import newspaperColumns from "./objects/newspaperColumns";
+import handwrittenNote from "./objects/handwrittenNote";
 
 export const schema = {
-  types: [authorType, blockContentType, categoryType, postType, figure, table, divider, accordion, codeBlock, chatConversation, containerColumns, newspaperColumns],
+  types: [authorType, blockContentType, categoryType, postType, figure, table, divider, accordion, codeBlock, chatConversation, containerColumns, newspaperColumns, handwrittenNote],
 };

--- a/src/sanity/schemaTypes/objects/handwrittenNote.ts
+++ b/src/sanity/schemaTypes/objects/handwrittenNote.ts
@@ -1,0 +1,88 @@
+import { defineType } from 'sanity';
+
+export default defineType({
+  name: 'handwrittenNote',
+  title: 'Handwritten Note',
+  type: 'object',
+  fields: [
+    {
+      name: 'content',
+      title: 'Note Content',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [
+            { title: 'Normal', value: 'normal' },
+          ],
+          lists: [
+            { title: 'Bullet (Dashes)', value: 'bullet' },
+            { title: 'Numbered', value: 'number' },
+          ],
+          marks: {
+            decorators: [
+              { title: 'Strong', value: 'strong' },
+              { title: 'Emphasis', value: 'em' },
+            ],
+            annotations: [],
+          },
+        },
+      ],
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'style',
+      title: 'Note Style',
+      type: 'string',
+      options: {
+        list: [
+          { title: '📝 Post-it Note', value: 'postit' },
+          { title: '📔 Field Notes', value: 'fieldnotes' },
+          { title: '📓 Notebook Page', value: 'notebook' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'postit',
+    },
+    {
+      name: 'colorVariant',
+      title: 'Color Variant',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Yellow', value: 'yellow' },
+          { title: 'Cream', value: 'cream' },
+          { title: 'Light Gray', value: 'gray' },
+          { title: 'Light Blue', value: 'blue' },
+          { title: 'Light Green', value: 'green' },
+        ],
+      },
+      initialValue: 'yellow',
+      hidden: ({ parent }: any) => parent?.style === 'postit' || parent?.style === 'notebook',
+    },
+  ],
+  preview: {
+    select: {
+      style: 'style',
+      colorVariant: 'colorVariant',
+      blocks: 'content',
+    },
+    prepare({ style, colorVariant, blocks }: any) {
+      const styleMap = {
+        postit: '📝 Post-it',
+        fieldnotes: '📔 Field Notes',
+        notebook: '📓 Notebook',
+      };
+      
+      // Get first line of content for preview
+      const block = (blocks || [])[0];
+      const text = block?.children?.[0]?.text || 'Empty note'; 
+      const preview = text.length > 50 ? text.substring(0, 50) + '...' : text;
+      
+      return {
+        title: `${styleMap[style as keyof typeof styleMap] || 'Handwritten Note'}`,
+        subtitle: `${colorVariant || ''} - ${preview}`,
+      };
+    },
+  },
+});

--- a/src/sanity/schemaTypes/post.ts
+++ b/src/sanity/schemaTypes/post.ts
@@ -124,6 +124,7 @@ export const postType = defineType({
         { type: 'chatConversation' },  // for chat conversations
         { type: 'containerColumns' },  // for two-column text comparisons (boxed)
         { type: 'newspaperColumns' },  // for newspaper-style columns (plain)
+        { type: 'handwrittenNote' },  // for handwritten notes
       ],
     }),
   ],


### PR DESCRIPTION
## Added Handwritten Note Component

This PR adds a new custom component for displaying handwritten-style notes in blog posts, with three distinct visual styles.

### Features

**Three Note Styles:**

1. **📝 Post-it Note**
   - Sharpie marker style with "Permanent Marker" font
   - Large, bold text (2.6rem) for emphasis
   - Locked to yellow background
   - 50% width (300px max-width)
   - Slight rotation for authentic sticky note feel
   - Perfect for highlighting key callouts

2. **📔 Field Notes**
   - Handwritten "Caveat" font
   - Horizontal ruled lines
   - 5 color variants: Yellow, Cream, Light Gray, Light Blue, Light Green
   - "FIELD NOTES" branding in corner
   - Bordered style with subtle shadows

3. **📓 Notebook Page**
   - Handwritten "Caveat" font
   - Red vertical margin line
   - Gray horizontal ruled lines aligned with text baseline
   - Fixed line-height (32px) for perfect line alignment
   - Locked light gray background (#f5f5f5)
   - Authentic notebook paper aesthetic

**Text Support:**
- Multi-line text support
- Bullet lists (dash style)
- Numbered lists
- Bold and italic formatting
- Nested lists

### Files Added
- `src/sanity/schemaTypes/objects/handwrittenNote.ts` - Sanity schema definition
- `src/components/PortableTextHandwrittenNote.astro` - React component with styling

### Files Modified
- `src/sanity/schemaTypes/index.ts` - Registered new schema
- `src/sanity/schemaTypes/post.ts` - Added to post body types
- `src/components/PortableText.astro` - Added component mapping

### Usage
In Sanity Studio, click the `+` button when editing a blog post and select "Handwritten Note". Choose your preferred style and color (where applicable), then add your content with full formatting support.
